### PR TITLE
Implement persistence of packing list, and command line flags to pack items

### DIFF
--- a/packingdb.sh
+++ b/packingdb.sh
@@ -3,5 +3,5 @@
 set -e
 export GOPATH="$(pwd)"
 go install github.com/ywwg/packingdb
-./bin/packingdb
+./bin/packingdb "$@"
 

--- a/src/github.com/ywwg/packingdb/packingdb.go
+++ b/src/github.com/ywwg/packingdb/packingdb.go
@@ -1,8 +1,9 @@
 package main
 
 import (
+	"flag"
 	"fmt"
-	"sort"
+	"os"
 
 	"github.com/ywwg/packinglib"
 
@@ -10,26 +11,51 @@ import (
 	_ "github.com/ywwg/items"
 )
 
+var (
+	flagContext     = flag.String("context", "", "The context you want to load (not needed if packing file exists)")
+	flagDays        = flag.Int("days", 0, "The number of days for the trip (not needed if packing file exists)")
+	flagPackingFile = flag.String("packfile", "", "The filename to create or load (not needed if you just want to print a list)")
+	flagPackItem    = flag.String("pack", "", "The name of an item that has been packed (noop without packfile)")
+)
+
 func main() {
-	t := packinglib.Trip{
-		Days: 4,
-		C:    packinglib.GetContext("firefly"),
+	flag.Parse()
+
+	var t *packinglib.Trip
+
+	// Simple mode: just print the list.
+	if *flagPackingFile == "" {
+		if len(*flagContext) == 0 {
+			panic("Need a context")
+		}
+		if *flagDays == 0 {
+			panic("Need a number of days")
+		}
+		t = packinglib.NewTrip(*flagDays, *flagContext)
+		for _, l := range t.Strings() {
+			fmt.Println(l)
+		}
+		return
 	}
 
-	packList := t.MakeList()
-	// map iteration is nondeterministic so sort the keys.
-	var keys []string
-	for k := range packList {
-		keys = append(keys, k)
+	// File mode: load if the file already exists
+	if _, err := os.Stat(*flagPackingFile); !os.IsNotExist(err) {
+		t = &packinglib.Trip{}
+		if err2 := t.LoadFromFile(*flagPackingFile); err2 != nil {
+			panic(fmt.Sprintf("%v", err2))
+		}
+	} else {
+		t = packinglib.NewTrip(*flagDays, *flagContext)
 	}
-	sort.Strings(keys)
 
-	for _, category := range keys {
-		if len(packList[category]) > 0 {
-			fmt.Printf("%s:\n", category)
-		}
-		for _, i := range packList[category] {
-			fmt.Println("\t" + i.String())
-		}
+	if *flagPackItem != "" {
+		t.Pack(*flagPackItem)
+	}
+	for _, l := range t.Strings() {
+		fmt.Println(l)
+	}
+
+	if err := t.SaveToFile(*flagPackingFile); err != nil {
+		panic(fmt.Sprintf("%v", err))
 	}
 }

--- a/src/github.com/ywwg/packingdb/packingdb.go
+++ b/src/github.com/ywwg/packingdb/packingdb.go
@@ -38,7 +38,7 @@ func main() {
 		return
 	}
 
-	// File mode: load if the file already exists
+	// File mode: load if the file already exists or create new if not
 	if _, err := os.Stat(*flagPackingFile); !os.IsNotExist(err) {
 		t = &packinglib.Trip{}
 		if err2 := t.LoadFromFile(*flagPackingFile); err2 != nil {

--- a/src/github.com/ywwg/packinglib/trip.go
+++ b/src/github.com/ywwg/packinglib/trip.go
@@ -3,21 +3,12 @@ package packinglib
 import (
 	"bufio"
 	"bytes"
-	"encoding/gob"
 	"fmt"
 	"io/ioutil"
 	"sort"
 	"strconv"
 	"strings"
 )
-
-func init() {
-	gob.Register(BasicItem{})
-	gob.Register(ConsumableItem{})
-	gob.Register(TemperatureItem{})
-	gob.Register(ConsumableTemperatureItem{})
-	gob.Register(CustomConsumableItem{})
-}
 
 // Trip describes a trip, which includes a length and a context
 type Trip struct {

--- a/src/github.com/ywwg/packinglib/trip.go
+++ b/src/github.com/ywwg/packinglib/trip.go
@@ -1,13 +1,30 @@
 package packinglib
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/gob"
 	"fmt"
+	"io/ioutil"
+	"sort"
+	"strconv"
+	"strings"
 )
+
+func init() {
+	gob.Register(BasicItem{})
+	gob.Register(ConsumableItem{})
+	gob.Register(TemperatureItem{})
+	gob.Register(ConsumableTemperatureItem{})
+	gob.Register(CustomConsumableItem{})
+}
 
 // Trip describes a trip, which includes a length and a context
 type Trip struct {
-	Days int
-	C    *Context
+	Days        int
+	C           *Context
+	contextName string
+	Packed      PackList
 }
 
 type PackList map[string][]Item
@@ -41,19 +58,101 @@ func GetContext(name string) *Context {
 	return c
 }
 
+func NewTrip(days int, context string) *Trip {
+	t := &Trip{
+		Days:        days,
+		C:           GetContext(context),
+		contextName: context,
+	}
+	t.Packed = t.makeList()
+	return t
+}
+
 // MakeList returns a map of category to slice of PackedItems for the given trip
-func (t *Trip) MakeList() PackList {
+func (t *Trip) makeList() PackList {
 	packlist := make(PackList)
 	for category, items := range AllItems {
-		var packed []Item
+		var toPack []Item
 		for _, i := range items {
-			p := i.Pack(t)
-			if p.Count() > 0 {
-				packed = append(packed, p)
+			calced := i.Itemize(t)
+			if calced.Count() > 0 {
+				toPack = append(toPack, calced)
 			}
 		}
-		packlist[category] = packed
+		packlist[category] = toPack
 	}
 
 	return packlist
+}
+
+func (t *Trip) Pack(i string) {
+	found := false
+	for _, items := range t.Packed {
+		for _, item := range items {
+			if item.Name() == i {
+				item.Pack()
+				found = true
+			}
+		}
+	}
+	if !found {
+		panic(fmt.Sprintf("tried to pack nonexistant item: ->%s<-", i))
+	}
+}
+
+func (t *Trip) Strings() []string {
+	var lines []string
+	// map iteration is nondeterministic so sort the keys.
+	var keys []string
+	for k := range t.Packed {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, category := range keys {
+		if len(t.Packed[category]) > 0 {
+			lines = append(lines, fmt.Sprintf("%s:", category))
+		}
+		for _, i := range t.Packed[category] {
+			lines = append(lines, fmt.Sprintf("\t%s", i.String()))
+		}
+	}
+	return lines
+}
+
+func (t *Trip) LoadFromFile(f string) error {
+	dat, err := ioutil.ReadFile(f)
+	if err != nil {
+		return err
+	}
+	buf := bytes.NewBuffer(dat)
+	scanner := bufio.NewScanner(buf)
+	for i := 0; scanner.Scan(); i++ {
+		toks := strings.SplitN(scanner.Text(), ",", 2)
+		if i == 0 {
+			days, err := strconv.Atoi(toks[0])
+			if err != nil {
+				return err
+			}
+			*t = *NewTrip(days, toks[1])
+		} else {
+			if toks[0] == "true" {
+				t.Pack(toks[1])
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		panic(fmt.Sprintf("reading file: %s", err))
+	}
+	return nil
+}
+
+func (t *Trip) SaveToFile(f string) error {
+	packedcsv := fmt.Sprintf("%d,%s\n", t.Days, t.contextName)
+	for _, items := range t.Packed {
+		for _, item := range items {
+			packedcsv += fmt.Sprintf("%v,%s\n", item.Packed(), item.Name())
+		}
+	}
+	return ioutil.WriteFile(f, []byte(packedcsv), 0644)
 }


### PR DESCRIPTION
    
    Now you can specify a filename which is a simple CSV file to save
    packed state to.  Then you can call packingdb multiple times with
    the --pack commandline arg to pack that item.
    
    NOTE: items therefore can't have duplicated names, but there's no checking for that.
